### PR TITLE
Update to 1.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
         maven {
             name = 'forge'
             url = 'http://files.minecraftforge.net/maven'
@@ -11,11 +12,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        classpath 'com.matthewprenger:CurseGradle:1.0-SNAPSHOT'
     }
 }
 
-apply plugin: 'forge'
+apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'com.matthewprenger.cursegradle'
 
 ext.build = System.getenv().BUILD_NUMBER ?: 'git'
 ext.modversion = "${project.version_major}.${project.version_minor}.${project.version_micro}.${build}"
@@ -28,6 +31,7 @@ compileJava.options.encoding = 'UTF-8'
 idea {
     module {
         downloadSources = true
+        inheritOutputDirs = true
     }
 }
 
@@ -60,6 +64,7 @@ processResources {
                 'modid'          : project.name,
                 'version'        : modversion,
                 'mcversion'      : project.version_minecraft,
+                'coreversion'    : project.version_lunatriuscore,
                 'forgeversion'   : project.version_forge,
                 'minforgeversion': project.hasProperty('version_minforge') ? project.version_minforge : project.version_forge
         ])
@@ -78,7 +83,7 @@ repositories {
 }
 
 dependencies {
-    compile group: group, name: 'LunatriusCore', version: "${project.version_minecraft}-${project.version_lunatriuscore}", classifier: 'dev'
+    compile group: group, name: 'LunatriusCore', version: "${project.version_minecraft}-${project.version_lunatriuscore}", classifier: 'universal'
 }
 
 def commonManifest = {
@@ -92,20 +97,7 @@ jar {
     manifest commonManifest
 }
 
-task devJar(dependsOn: 'classes', type: Jar) {
-    from sourceSets.main.output
-    classifier = 'dev'
-    manifest commonManifest
-}
-
-task sourceJar(dependsOn: 'classes', type: Jar) {
-    from sourceSets.main.allSource
-    classifier = 'sources'
-    manifest commonManifest
-}
-
 artifacts {
-    archives devJar
     archives sourceJar
 }
 
@@ -118,7 +110,7 @@ if (!project.hasProperty('keystore_alias'))
 if (!project.hasProperty('keystore_password'))
     ext.keystore_password = ''
 
-task signJars(dependsOn: ['reobf', 'devJar', 'sourceJar']) {
+task signJars(dependsOn: ['reobfJar', 'sourceJar']) {
     inputs.dir jar.destinationDir
     inputs.file keystore_location
     inputs.property 'keystore_alias', keystore_alias

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 version_major=1
 version_minor=1
-version_micro=0
-version_minecraft=1.7.10
-version_forge=10.13.2.1291
-version_minforge=10.13.0.1180
-version_lunatriuscore=1.1.2.21
+version_micro=1
+version_minecraft=1.10.2
+version_forge=12.18.3.2281
+version_minforge=12.18.0.2008
+version_lunatriuscore=1.1.2.38
+version_mappings=snapshot_20160701
 
 extra_modsio_id=1054

--- a/src/main/java/com/github/lunatrius/imc/DynIMC.java
+++ b/src/main/java/com/github/lunatrius/imc/DynIMC.java
@@ -8,14 +8,15 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.ModMetadata;
-import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLInterModComms;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.DummyModContainer;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.Mod.Instance;
+import net.minecraftforge.fml.common.ModMetadata;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -51,13 +52,15 @@ public class DynIMC {
         if (Loader.isModLoaded("LunatriusCore")) {
             registerVersionChecker(event.getModMetadata());
         }
+        
+        if (this.directory != null) {
+            readConfiguration(this.directory);
+        }
     }
 
     @EventHandler
     public void init(FMLInitializationEvent event) {
-        if (this.directory != null) {
-            readConfiguration(this.directory);
-        }
+    	
     }
 
     private void readConfiguration(File configurationDirectory) {
@@ -89,9 +92,9 @@ public class DynIMC {
                             for (ItemStack itemStack : entry.getValue()) {
                                 if (itemStack != null && itemStack.getItem() != null) {
                                     Reference.logger.trace("Sending IMC message " + entry.getKey() + ": " + itemStack);
-                                    FMLInterModComms.sendRuntimeMessage(Reference.MODID, modIMC.modid, entry.getKey(), itemStack);
+                                    FMLInterModComms.sendMessage(modIMC.modid, entry.getKey(), itemStack);
                                 } else {
-                                    Reference.logger.warn("Tried to send null IMC message " + entry.getKey());
+                                    Reference.logger.trace("Tried to send null IMC message " + entry.getKey());
                                 }
                             }
                         }
@@ -102,9 +105,9 @@ public class DynIMC {
                             for (String string : entry.getValue()) {
                                 if (string != null) {
                                     Reference.logger.trace("Sending IMC message " + entry.getKey() + ": " + string);
-                                    FMLInterModComms.sendRuntimeMessage(Reference.MODID, modIMC.modid, entry.getKey(), string);
+                                    FMLInterModComms.sendMessage(modIMC.modid, entry.getKey(), string);
                                 } else {
-                                    Reference.logger.warn("Tried to send null IMC message " + entry.getKey());
+                                    Reference.logger.trace("Tried to send null IMC message " + entry.getKey());
                                 }
                             }
                         }
@@ -115,9 +118,9 @@ public class DynIMC {
                             for (NBTTagCompound nbt : entry.getValue()) {
                                 if (nbt != null) {
                                     Reference.logger.trace("Sending IMC message " + entry.getKey() + ": " + String.valueOf(nbt));
-                                    FMLInterModComms.sendRuntimeMessage(Reference.MODID, modIMC.modid, entry.getKey(), nbt);
+                                    FMLInterModComms.sendMessage(modIMC.modid, entry.getKey(), nbt);
                                 } else {
-                                    Reference.logger.warn("Tried to send a null IMC message " + entry.getKey());
+                                    Reference.logger.trace("Tried to send a null IMC message " + entry.getKey());
                                 }
                             }
                         }
@@ -128,7 +131,8 @@ public class DynIMC {
     }
 
     private void registerVersionChecker(ModMetadata modMetadata) {
-        VersionChecker.registerMod(modMetadata, Reference.FORGE);
+    	DummyModContainer container = new DummyModContainer(modMetadata);
+    	VersionChecker.registerMod(container, Reference.FORGE);
     }
 
     private List<ModIMC> readFile(File file) {

--- a/src/main/java/com/github/lunatrius/imc/deserializer/ItemStackDeserializer.java
+++ b/src/main/java/com/github/lunatrius/imc/deserializer/ItemStackDeserializer.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import cpw.mods.fml.common.registry.GameData;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -33,10 +32,10 @@ public class ItemStackDeserializer implements JsonDeserializer<ItemStack> {
         int itemDamage = jsonObject.has(ITEM_DAMAGE) ? jsonObject.get(ITEM_DAMAGE).getAsInt() : DEFAULT_ITEM_DAMAGE;
 
         if (jsonObject.has(BLOCK)) {
-            Block block = GameData.getBlockRegistry().getObject(jsonObject.get(BLOCK).getAsString());
+            Block block = Block.getBlockFromName(jsonObject.get(BLOCK).getAsString());
             return new ItemStack(block, stackSize, itemDamage);
         } else if (jsonObject.has(ITEM)) {
-            Item item = GameData.getItemRegistry().getObject(jsonObject.get(ITEM).getAsString());
+            Item item = Item.getByNameOrId(jsonObject.get(BLOCK).getAsString());
             return new ItemStack(item, stackSize, itemDamage);
         }
 

--- a/src/main/java/com/github/lunatrius/imc/deserializer/NBTTagCompoundDeserializer.java
+++ b/src/main/java/com/github/lunatrius/imc/deserializer/NBTTagCompoundDeserializer.java
@@ -8,8 +8,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
-import cpw.mods.fml.common.registry.GameData;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTPrimitive;
 import net.minecraft.nbt.NBTTagByte;
 import net.minecraft.nbt.NBTTagByteArray;
 import net.minecraft.nbt.NBTTagCompound;
@@ -21,6 +22,8 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagLong;
 import net.minecraft.nbt.NBTTagShort;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -77,24 +80,12 @@ public class NBTTagCompoundDeserializer implements JsonDeserializer<NBTTagCompou
                 }
                 return new NBTTagByte(value.getAsByte());
             } else if (type.equalsIgnoreCase(TYPE_SHORT)) {
-                NBTBase.NBTPrimitive primitive = getIdFromString(value, type);
-
-                if (primitive != null) {
-                    return primitive;
-                }
-
                 final String str = value.getAsString();
                 if (str.startsWith("0x")) {
                     return new NBTTagShort(Short.parseShort(str.substring(2), 0x10));
                 }
                 return new NBTTagShort(value.getAsShort());
             } else if (type.equalsIgnoreCase(TYPE_INT)) {
-                NBTBase.NBTPrimitive primitive = getIdFromString(value, type);
-
-                if (primitive != null) {
-                    return primitive;
-                }
-
                 final String str = value.getAsString();
                 if (str.startsWith("0x")) {
                     return new NBTTagInt(Integer.parseInt(str.substring(2), 0x10));
@@ -122,44 +113,6 @@ public class NBTTagCompoundDeserializer implements JsonDeserializer<NBTTagCompou
                 return getIntArray(value.getAsJsonArray());
             }
         }
-        return null;
-    }
-
-    private NBTBase.NBTPrimitive getIdFromString(JsonElement jsonElement, String type) {
-        if (jsonElement.isJsonPrimitive()) {
-            JsonPrimitive jsonPrimitive = jsonElement.getAsJsonPrimitive();
-
-            if (jsonPrimitive.isString()) {
-                final String name = jsonPrimitive.getAsString();
-                final String[] split = name.split(DELIMITER_ITEM_BLOCK, 2);
-                int id = -1;
-
-                if (split.length == 2) {
-                    if (split[0].equalsIgnoreCase(ID_TYPE_BLOCK)) {
-                        id = GameData.getBlockRegistry().getId(split[1]);
-                    } else if (split[0].equalsIgnoreCase(ID_TYPE_ITEM)) {
-                        id = GameData.getItemRegistry().getId(split[1]);
-                    }
-                } else {
-                    id = GameData.getBlockRegistry().getId(split[0]);
-
-                    if (id == -1) {
-                        id = GameData.getItemRegistry().getId(split[0]);
-                    }
-                }
-
-                if (id < 0) {
-                    Reference.logger.fatal(String.format("The block/item %s could not be found!", name));
-                }
-
-                if (type.equalsIgnoreCase(TYPE_SHORT)) {
-                    return new NBTTagShort((short) id);
-                } else if (type.equalsIgnoreCase(TYPE_INT)) {
-                    return new NBTTagInt(id);
-                }
-            }
-        }
-
         return null;
     }
 


### PR DESCRIPTION
Parsing of IDs from names was no longer necessary as IDs are depreciated, which makes matters much simpler.

Unsure of the best way to generate a ModContainer object from the ModMetadata in order to make use of Lunatrius Core's new VersionChecker.registerMod. Am currently generating a DummyModContainer from the metadata and passing that, which appears to work.